### PR TITLE
added logic for light or dark theme on camera button

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2024-11-06T23:46:47.926946900Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Sondre\.android\avd\Medium_Phone_API_35.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/src/main/java/no/hiof/mobilproggroup3/MainActivity.kt
+++ b/app/src/main/java/no/hiof/mobilproggroup3/MainActivity.kt
@@ -267,7 +267,7 @@ fun MainScreen(
 
             Spacer(modifier = Modifier.height(80.dp))
 
-            //button for capturing image, its pretty basic
+            //button for capturing image
             Row (){
             IconButton(onClick = {
                 imageCapture?.takePicture(
@@ -293,12 +293,21 @@ fun MainScreen(
                 }
             )
             }) {
-                Image(
+                //if darktheme on phone camera button changes to white, else black camera button
+                //code logic is not visible on emulator, but on the mobile device it works.
+                if(isSystemInDarkTheme()) {
+                    Image(
+                        painterResource(R.drawable.baseline_camera_24_white),
+                        contentDescription = "Camera button, capture text",
+                        modifier = Modifier.size(48.dp)
+                    )
+                } else {
+                    Image(
                     painterResource(R.drawable.baseline_camera_24),
                     contentDescription = "Camera button, capture text",
-                    modifier = Modifier.size(48.dp)
-                )
+                    modifier = Modifier.size(48.dp))
                 }
+            }
             Spacer(modifier = Modifier.height(20.dp))
 
             //button for capture/recognize text

--- a/app/src/main/res/drawable/baseline_camera_24_white.xml
+++ b/app/src/main/res/drawable/baseline_camera_24_white.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M9.4,10.5l4.77,-8.26C13.47,2.09 12.75,2 12,2c-2.4,0 -4.6,0.85 -6.32,2.25l3.66,6.35 0.06,-0.1zM21.54,9c-0.92,-2.92 -3.15,-5.26 -6,-6.34L11.88,9h9.66zM21.8,10h-7.49l0.29,0.5 4.76,8.25C21,16.97 22,14.61 22,12c0,-0.69 -0.07,-1.35 -0.2,-2zM8.54,12l-3.9,-6.75C3.01,7.03 2,9.39 2,12c0,0.69 0.07,1.35 0.2,2h7.49l-1.15,-2zM2.46,15c0.92,2.92 3.15,5.26 6,6.34L12.12,15L2.46,15zM13.73,15l-3.9,6.76c0.7,0.15 1.42,0.24 2.17,0.24 2.4,0 4.6,-0.85 6.32,-2.25l-3.66,-6.35 -0.93,1.6z"/>
+    
+</vector>


### PR DESCRIPTION
if darktheme on phone camera button changes to white, else black color camera button
code logic is not visible on emulator, but on the mobile device it works.